### PR TITLE
fix overlay isVisible checkbox remains checked

### DIFF
--- a/src/content/Overlay/overlay.playground.jsx
+++ b/src/content/Overlay/overlay.playground.jsx
@@ -14,6 +14,16 @@ const OverlayPlayground = () => {
       children: {
         type: PropTypes.ReactNode,
         value: `<Text>Some content</Text><TouchableOpacity onPress={()=>setIsVisible(!isVisible)}><Text>Click to close</Text></TouchableOpacity>`,
+        propHook: ({getInstrumentOnChange, fnBodyAppend}) => ({
+          JSXAttribute(path) {
+            if (path.get('name').node.name === 'onPress') {
+              fnBodyAppend(
+                path.get('value'),
+                getInstrumentOnChange('false', 'isVisible')
+              );
+            }
+          },
+        }),
       },
       isVisible: {
         type: PropTypes.Boolean,

--- a/src/content/Overlay/overlay.playground.jsx
+++ b/src/content/Overlay/overlay.playground.jsx
@@ -33,6 +33,10 @@ const OverlayPlayground = () => {
       onBackdropPress: {
         type: PropTypes.Function,
         value: `() => setIsVisible(!isVisible)`,
+        propHook: {
+          what: `false`,
+          into: `isVisible`,
+        }
       },
     },
     scope: {


### PR DESCRIPTION
fixes: #61 

Edit: Finally found a way to hook props to the children using react-view AST. Now it works for both on clicking backdrop and TouchableOpacity