### PR TITLE
🚀feat: add to all prop_explorers with complete prop detailing from RNE CORE 

### DIFF
--- a/src/content/AirbnbRating/airbnb.mdx
+++ b/src/content/AirbnbRating/airbnb.mdx
@@ -1,0 +1,68 @@
+# Props
+
+- [`count`](#count)
+- [`defaultRating`](#defaultRating)
+- [`onFinishRating`](#onFinishRating)
+- [`reviews`](#reviews)
+- [`showRating`](#showRating)
+
+---
+
+# Child Components
+
+### Accessory
+
+> Receives either all [Icon](icon.md#props) or [Image](image.md#props) props.
+
+---
+
+# Reference
+
+### `accessory`
+
+Icon or Image used as small overlay.
+If a `source` key is used in the object, then an Image will be used.
+
+|                                  Type                                  |                                    Default                                    |
+| :--------------------------------------------------------------------: | :---------------------------------------------------------------------------: |
+| {[...Icon props](icon.md#props)} or {[...Image props](image.md#props)} | { name: 'mode-edit', type: 'material', color: '#fff', underlayColor: '#000' } |
+
+---
+
+### `count`
+
+Total number of ratings to display
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |   5     |
+
+---
+
+### `defaultRating`
+
+Initial value for the rating defaultRating
+
+|      Type      | Default |
+| :------------: | :-----: |
+|     number     |  1      |
+
+---
+
+### `reviews`
+
+Labels to show when each value is tapped e.g. If the first star is tapped, then value in index 0 will be used as the label
+
+|   Type   |                  Default                     |
+| :------: | :------------------------------------------: |
+| string[] | ['Terrible', 'Bad', 'Okay', 'Good', 'Great'] |
+
+---
+
+### `onFinishRating`
+
+Callback method when the user finishes rating. Gives you the final rating value as a whole number (required)
+
+|      Type      | Default |
+| :------------: | :-----: |
+|    function    |  none   |

--- a/src/content/AirbnbRating/airbnb.mdx
+++ b/src/content/AirbnbRating/airbnb.mdx
@@ -8,26 +8,7 @@
 
 ---
 
-# Child Components
-
-### Accessory
-
-> Receives either all [Icon](icon.md#props) or [Image](image.md#props) props.
-
----
-
 # Reference
-
-### `accessory`
-
-Icon or Image used as small overlay.
-If a `source` key is used in the object, then an Image will be used.
-
-|                                  Type                                  |                                    Default                                    |
-| :--------------------------------------------------------------------: | :---------------------------------------------------------------------------: |
-| {[...Icon props](icon.md#props)} or {[...Image props](image.md#props)} | { name: 'mode-edit', type: 'material', color: '#fff', underlayColor: '#000' } |
-
----
 
 ### `count`
 

--- a/src/content/AirbnbRating/index.jsx
+++ b/src/content/AirbnbRating/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./searchbar.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./airbnb.mdx"));
 
 export default function AirbnbPlayground() {
   return (
     <div>
       <Playground />
+        <Suspense fallback={<div>Loading...</div>}>
+          <PropDrawer>
+            <Content />
+          </PropDrawer>
+        </Suspense>
     </div>
   );
 }

--- a/src/content/Avatar/avatar.mdx
+++ b/src/content/Avatar/avatar.mdx
@@ -1,4 +1,4 @@
-## Props
+# Props
 
 - [`activeOpacity`](#activeopacity)
 - [`avatarStyle`](#avatarstyle)

--- a/src/content/BottomSheet/bottomsheet.mdx
+++ b/src/content/BottomSheet/bottomsheet.mdx
@@ -1,0 +1,39 @@
+# Props
+
+- [`containerStyle`](#containerStyle)
+- [`isVisible`](#isvisible)
+- [`modalProps`](#modalprops)
+
+---
+
+# Reference
+
+### `containerStyle`
+
+Style of the bottom sheet's container
+
+Use this to change the color of the underlay
+
+|        Type         |    Default     |
+| :-----------------: | :------------: |
+| View style (object) | Internal Style |
+
+---
+
+### `isVisible`
+
+Is the modal component shown
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `modalProps`
+
+Additional props handed to the `Modal`
+
+|                             Type                             | Default |
+| :----------------------------------------------------------: | :-----: |
+| [Modal Props](https://reactnative.dev/docs/modal.html#props) |   {}    |

--- a/src/content/BottomSheet/index.jsx
+++ b/src/content/BottomSheet/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./bottomsheet.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./bottomsheet.mdx"));
 
 export default function BottomSheetPlayground() {
   return (
     <div>
       <Playground />
+        <Suspense fallback={<div>Loading...</div>}>
+          <PropDrawer>
+            <Content />
+          </PropDrawer>
+        </Suspense>
     </div>
   );
 }

--- a/src/content/ButtonGroup/buttongroup.mdx
+++ b/src/content/ButtonGroup/buttongroup.mdx
@@ -1,0 +1,226 @@
+# Props
+
+- [`buttonContainerStyle`](#buttonContainerStyle)
+- [`buttons`](#buttons)
+- [`buttonStyle`](#buttonStyle)
+- [`Component`](#Component)
+- [`containerStyle`](#containerStyle)
+- [`disabled`](#disabled)
+- [`disabledSelectedStyle`](#disabledSelectedStyle)
+- [`disabledSelectedTextStyle`](#disabledSelectedTextStyle)
+- [`disabledStyle`](#disabledStyle)
+- [`disabledTextStyle`](#disabledTextStyle)
+- [`innerBorderStyle`](#innerBorderStyle)
+- [`onPress`](#onPress)
+- [`selectedButtonStyle`](#selectedButtonStyle)
+- [`selectedIndex`](#selectedIndex)
+- [`selectedIndexes`](#selectedIndexes)
+- [`selectedTextStyle`](#selectedTextStyle)
+- [`selectMultiple`](#selectMultiple)
+- [`textStyle`](#textStyle)
+- [`underlayColor`](#underlayColor)
+- [`vertical`](#vertical)
+
+---
+
+# Reference
+
+### `buttonContainerStyle`
+
+specify styling for button containers (optional)
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `buttons`
+
+array of buttons for component (required), if returning a component, must be an
+object with { element: componentName }
+
+| Type  | Default |
+| :---: | :-----: |
+| array |  none   |
+
+---
+
+### `buttonStyle`
+
+specify styling for button (optional)
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `Component`
+
+Choose other button component such as TouchableOpacity (optional)
+
+|          Type          |                           Default                           |
+| :--------------------: | :---------------------------------------------------------: |
+| React Native Component | TouchableOpacity (ios) or TouchableNativeFeedback (android) |
+
+---
+
+### `containerStyle`
+
+specify styling for main button container (optional)
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `disabled`
+
+Controls if buttons are disabled. Setting `true` makes all of them disabled,
+while using an array only makes those indices disabled.
+
+|          Type           | Default |
+| :---------------------: | :-----: |
+| boolean **OR** number[] |  false  |
+
+---
+
+### `disabledSelectedStyle`
+
+Styling for each selected button when disabled.
+
+|        Type         |    Default     |
+| :-----------------: | :------------: |
+| View style (object) | Internal Style |
+
+---
+
+### `disabledSelectedTextStyle`
+
+Styling for the text of each selected button when disabled.
+
+|        Type         |    Default     |
+| :-----------------: | :------------: |
+| Text style (object) | Internal Style |
+
+---
+
+### `disabledStyle`
+
+Styling for each button when disabled.
+
+|        Type         |    Default     |
+| :-----------------: | :------------: |
+| View style (object) | Internal Style |
+
+---
+
+### `disabledTextStyle`
+
+Styling for the text of each button when disabled.
+
+|        Type         |    Default     |
+| :-----------------: | :------------: |
+| Text style (object) | Internal Style |
+
+---
+
+### `innerBorderStyle`
+
+update the styling of the interior border of the list of buttons (optional)
+
+|          Type           |      Default      |
+| :---------------------: | :---------------: |
+| object { width, color } | inherited styling |
+
+---
+
+### `onPress`
+
+method to update Button Group Index (required)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `selectedButtonStyle`
+
+specify styling for selected button (optional)
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `selectedIndex`
+
+current selected index of array of buttons (required)
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |  none   |
+
+---
+
+### `selectedIndexes`
+
+current selected indexes from the array of buttons
+
+|      Type      | Default |
+| :------------: | :-----: |
+| array (number) |   []    |
+
+---
+
+### `selectedTextStyle`
+
+specify specific styling for text in the selected state (optional)
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `selectMultiple`
+
+allows the user to select multiple buttons
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `textStyle`
+
+specify specific styling for text (optional)
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `underlayColor`
+
+specify underlayColor for TouchableHighlight (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  white  |
+
+---
+
+### `vertical`
+
+Display the ButtonGroup vertically
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |

--- a/src/content/ButtonGroup/index.jsx
+++ b/src/content/ButtonGroup/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./buttongroup.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./buttongroup.mdx"));
 
 export default function ButtonGroupPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/Card/card.mdx
+++ b/src/content/Card/card.mdx
@@ -1,0 +1,50 @@
+# Props
+
+- [`containerStyle`](#containerstyle)
+- [`wrapperStyle`](#wrapperstyle)
+
+---
+
+# Child Components
+
+### Card.Divider
+
+> Receives all [Divider](divider.md#props) props.
+
+### Card.Title
+
+> Receives all [Text](text.md#props) props.
+
+### Card.Image
+
+> Receives all [Image](image.md#props) props.
+
+### Card.FeaturedTitle
+
+> Receives all [Text](text.md#props) props.
+
+### Card.FeaturedSubtitle
+
+> Receives all [Text](text.md#props) props.
+
+---
+
+# Reference
+
+### `containerStyle`
+
+outer container style (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `wrapperStyle`
+
+inner container style (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |

--- a/src/content/Card/index.jsx
+++ b/src/content/Card/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./card.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./card.mdx"));
 
 export default function CardPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/CheckBox/checkbox.mdx
+++ b/src/content/CheckBox/checkbox.mdx
@@ -1,0 +1,237 @@
+# Props
+
+- [`center`](#center)
+- [`checked`](#checked)
+- [`checkedColor`](#checkedcolor)
+- [`checkedIcon`](#checkedicon)
+- [`checkedTitle`](#checkedtitle)
+- [`Component`](#Component)
+- [`containerStyle`](#containerstyle)
+- [`fontFamily`](#fontfamily)
+- [`iconRight`](#iconright)
+- [`iconType`](#icontype)
+- [`onIconPress`](#oniconpress)
+- [`onLongIconPress`](#onlongiconpress)
+- [`onLongPress`](#onlongpress)
+- [`onPress`](#onpress)
+- [`right`](#right)
+- [`size`](#size)
+- [`textStyle`](#textstyle)
+- [`title`](#title)
+- [`titleProps`](#titleprops)
+- [`uncheckedColor`](#uncheckedcolor)
+- [`uncheckedIcon`](#uncheckedicon)
+
+---
+
+# Reference
+
+### `center`
+
+Aligns checkbox to center (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `checked`
+
+Flag for checking the icon (required)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `checkedColor`
+
+Default checked color (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  green  |
+
+---
+
+### `checkedIcon`
+
+Default checked icon ([Font Awesome Icon](http://fontawesome.io/icons/))
+(optional)
+
+|               Type               |    Default     |
+| :------------------------------: | :------------: |
+| string OR React Native Component | check-square-o |
+
+---
+
+### `checkedTitle`
+
+Specify a custom checked message (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |
+
+---
+
+### `Component`
+
+Specify React Native component for main button (optional)
+
+|          Type          |     Default      |
+| :--------------------: | :--------------: |
+| React Native Component | TouchableOpacity |
+
+---
+
+### `containerStyle`
+
+Style of main container (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `fontFamily`
+
+Specify different font family
+
+|  Type  |                      Default                      |
+| :----: | :-----------------------------------------------: |
+| string | System font bold (iOS), Sans Serif Bold (android) |
+
+---
+
+### `iconRight`
+
+Moves icon to right of text (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `iconType`
+
+type of icon set. [Supported sets here](icon.md#available-icon-sets).
+
+|  Type  |   Default    |
+| :----: | :----------: |
+| string | font-awesome |
+
+---
+
+### `onIconPress`
+
+onPress function for checkbox (required)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `onLongIconPress`
+
+onLongPress function for checkbox (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `onLongPress`
+
+onLongPress function for checkbox (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `onPress`
+
+onPress function for container (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `right`
+
+Aligns checkbox to right (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `size`
+
+Size of the checkbox
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |   24    |
+
+---
+
+### `textStyle`
+
+Style of text (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `title`
+
+Title of checkbox
+
+|               Type               | Default |
+| :------------------------------: | :-----: |
+| string OR React Native Component |  none   |
+
+---
+
+### `titleProps`
+
+Additional props for the title Text component (optional)
+
+|                             Type                             | Default |
+| :----------------------------------------------------------: | :-----: |
+| {[...Text props](https://reactnative.dev/docs/text#props-1)} |  none   |
+
+---
+
+### `uncheckedColor`
+
+Default unchecked color (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string | #bfbfbf |
+
+---
+
+### `uncheckedIcon`
+
+Default checked icon ([Font Awesome Icon](http://fontawesome.io/icons/))
+(optional)
+
+|               Type               | Default  |
+| :------------------------------: | :------: |
+| string OR React Native Component | square-o |

--- a/src/content/CheckBox/index.jsx
+++ b/src/content/CheckBox/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./checkbox.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./checkbox.mdx"));
 
 export default function CheckBoxPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/Divider/divider.mdx
+++ b/src/content/Divider/divider.mdx
@@ -1,0 +1,18 @@
+# Props
+
+> Also receives all
+> [View](https://reactnative.dev/docs/view#props) props
+
+- [`style`](#style)
+
+---
+
+# Reference
+
+### `style`
+
+Style of the divider
+
+|     Type     |                Default                |
+| :----------: | :-----------------------------------: |
+| style object | {height: 1, backgroundColor: #e1e8ee} |

--- a/src/content/Divider/index.jsx
+++ b/src/content/Divider/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./divider.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./divider.mdx"));
 
 export default function DividerPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/Header/header.mdx
+++ b/src/content/Header/header.mdx
@@ -1,0 +1,169 @@
+# Props
+
+- [`backgroundColor`](#backgroundcolor)
+- [`backgroundImage`](#backgroundimage)
+- [`backgroundImageStyle`](#backgroundimagestyle)
+- [`barStyle`](#barstyle)
+- [`centerComponent`](#centercomponent)
+- [`centerContainerStyle`](#centercontainerstyle)
+- [`containerStyle`](#containerstyle)
+- [`leftComponent`](#leftcomponent)
+- [`leftContainerStyle`](#leftcontainerstyle)
+- [`linearGradientProps`](#lineargradientprops)
+- [`placement`](#placement)
+- [`rightComponent`](#rightcomponent)
+- [`rightContainerStyle`](#rightcontainerstyle)
+- [`statusBarProps`](#statusbarprops)
+- [`ViewComponent`](#viewcomponent)
+
+---
+
+# Reference
+
+### `backgroundColor`
+
+sets backgroundColor of the parent component
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |
+
+---
+
+### `backgroundImage`
+
+sets backgroundImage for parent component
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (image) |  none   |
+
+---
+
+### `backgroundImageStyle`
+
+styling for backgroundImage in the main container
+
+| Type  | Default |
+| :---: | :-----: |
+| style |  none   |
+
+---
+
+### `barStyle`
+
+Sets the color of the status bar text.
+
+|                    Type                    |                                  Default                                   |
+| :----------------------------------------: | :------------------------------------------------------------------------: |
+| 'default', 'light-content', 'dark-content' | 'default' ([source](https://reactnative.dev/docs/statusbar.html#barstyle)) |
+
+---
+
+### `centerComponent`
+
+define your center component here
+
+|                                                                                           Type                                                                                            | Default |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
+| { text: string, [...Text props](https://reactnative.dev/docs/text.html#props)}<br/>**OR**<br/>{ icon: string, [...Icon props](icon.md#props)} <br/>**OR**<br/> React element or component |  none   |
+
+---
+
+### `centerContainerStyle`
+
+styling for container around the centerComponent
+
+| Type  |   Default   |
+| :---: | :---------: |
+| style | { flex: 3 } |
+
+---
+
+### `containerStyle`
+
+styling around the main container
+
+| Type  | Default |
+| :---: | :-----: |
+| style |  none   |
+
+---
+
+### `leftComponent`
+
+define your left component here
+
+|                                                                                           Type                                                                                            | Default |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
+| { text: string, [...Text props](https://reactnative.dev/docs/text.html#props)}<br/>**OR**<br/>{ icon: string, [...Icon props](icon.md#props)} <br/>**OR**<br/> React element or component |  none   |
+
+---
+
+### `leftContainerStyle`
+
+styling for container around the leftComponent
+
+| Type  |   Default   |
+| :---: | :---------: |
+| style | { flex: 1 } |
+
+---
+
+### `linearGradientProps`
+
+displays a linear gradient. See [usage](#lineargradient-usage).
+
+|                                                      Type                                                      | Default |
+| :------------------------------------------------------------------------------------------------------------: | :-----: |
+| {[...Gradient props](https://github.com/react-native-community/react-native-linear-gradient#additional-props)} |  none   |
+
+---
+
+### `placement`
+
+Alignment for title
+
+|            Type             | Default  |
+| :-------------------------: | :------: |
+| 'left', 'center' or 'right' | 'center' |
+
+---
+
+### `rightComponent`
+
+define your right component here
+
+|                                                                                           Type                                                                                            | Default |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
+| { text: string, [...Text props](https://reactnative.dev/docs/text.html#props)}<br/>**OR**<br/>{ icon: string, [...Icon props](icon.md#props)} <br/>**OR**<br/> React element or component |  none   |
+
+---
+
+### `rightContainerStyle`
+
+styling for container around the rightComponent
+
+| Type  |   Default   |
+| :---: | :---------: |
+| style | { flex: 1 } |
+
+---
+
+### `statusBarProps`
+
+accepts all props for StatusBar
+
+|                                    Type                                     | Default |
+| :-------------------------------------------------------------------------: | :-----: |
+| { [...StatusBar props](https://reactnative.dev/docs/statusbar.html#props) } |  none   |
+
+---
+
+### `ViewComponent`
+
+component for container
+
+|          Type          |     Default     |
+| :--------------------: | :-------------: |
+| React Native Component | ImageBackground |

--- a/src/content/Header/index.jsx
+++ b/src/content/Header/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./header.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./header.mdx"));
 
 export default function HeaderPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/Icon/icon.mdx
+++ b/src/content/Icon/icon.mdx
@@ -1,0 +1,203 @@
+# Props
+
+- [`brand`](#brand)
+- [`color`](#color)
+- [`Component`](#Component)
+- [`containerStyle`](#containerstyle)
+- [`disabled`](#disabled)
+- [`disabledStyle`](#disabledstyle)
+- [`iconProps`](#iconprops)
+- [`iconStyle`](#iconstyle)
+- [`name`](#name)
+- [`onLongPress`](#onlongpress)
+- [`onPress`](#onpress)
+- [`raised`](#raised)
+- [`reverse`](#reverse)
+- [`reverseColor`](#reversecolor)
+- [`size`](#size)
+- [`solid`](#solid)
+- [`type`](#type)
+- [`underlayColor`](#underlaycolor)
+
+---
+
+# Reference
+
+### `brand`
+
+Uses the brands font (FontAwesome5 only)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `color`
+
+color of icon (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  black  |
+
+---
+
+### `Component`
+
+update React Native Component (optional)
+
+|          Type          |                                        Default                                        |
+| :--------------------: | :-----------------------------------------------------------------------------------: |
+| React Native component | View if no onPress method is defined, TouchableHighlight if onPress method is defined |
+
+---
+
+### `containerStyle`
+
+add styling to container holding icon (optional)
+
+|        Type         |      Default      |
+| :-----------------: | :---------------: |
+| View style (object) | inherited styling |
+
+---
+
+### `disabled`
+
+Disables onPress events (optional). Only works when `onPress` has a handler.
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `disabledStyle`
+
+Style for the button when disabled (optional). Only works when `onPress` has a
+handler.
+
+|        Type         |              Default               |
+| :-----------------: | :--------------------------------: |
+| View style (object) | `{{ backgroundColor: '#D1D5D8' }}` |
+
+---
+
+### `iconProps`
+
+provide all props from react-native Icon component
+
+|                                          Type                                          | Default |
+| :------------------------------------------------------------------------------------: | :-----: |
+| {[...Icon props](https://github.com/oblador/react-native-vector-icons#icon-component)} |  none   |
+
+---
+
+### `iconStyle`
+
+additional styling to icon (optional)
+
+|        Type         |     Default     |
+| :-----------------: | :-------------: |
+| View style (object) | inherited style |
+
+---
+
+### `name`
+
+name of icon (required)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |
+
+---
+
+### `onLongPress`
+
+onLongPress method for button (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `onPress`
+
+onPress method for button (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `raised`
+
+adds box shadow to button (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `reverse`
+
+reverses color scheme (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `reverseColor`
+
+specify reverse icon color (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  white  |
+
+---
+
+### `size`
+
+size of icon (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |   26    |
+
+---
+
+### `solid`
+
+Uses the solid font (FontAwesome5 only)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `type`
+
+type of icon set. [Supported sets here](#available-icon-sets).
+
+|  Type  | Default  |
+| :----: | :------: |
+| string | material |
+
+---
+
+### `underlayColor`
+
+underlayColor for press event
+
+|  Type  |  Default   |
+| :----: | :--------: |
+| string | icon color |

--- a/src/content/Icon/index.jsx
+++ b/src/content/Icon/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./icon.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./icon.mdx"));
 
 export default function IconPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/Image/image.mdx
+++ b/src/content/Image/image.mdx
@@ -1,0 +1,97 @@
+# Props
+
+> Also receives all
+> [React Native Image](https://reactnative.dev/docs/image#props) props
+>
+> Contains all
+> [React Native Image](https://reactnative.dev/docs/image#methods) methods.
+
+- [`containerStyle`](#containerstyle)
+- [`ImageComponent`](#imagecomponent)
+- [`onLongPress`](#onlongpress)
+- [`onPress`](#onpress)
+- [`PlaceholderContent`](#placeholdercontent)
+- [`placeholderStyle`](#placeholderstyle)
+- [`transition`](#transition)
+
+---
+
+# Reference
+
+### `containerStyle`
+
+Additional styling for the container (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| View style (object) |  none   |
+
+---
+
+### `ImageComponent`
+
+Specify a different component as the Image component.
+
+|          Type          | Default |
+| :--------------------: | :-----: |
+| React Native Component |  Image  |
+
+---
+
+### `onLongPress`
+
+Callback function when long pressing component
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `onPress`
+
+Callback function when pressing component
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `PlaceholderContent`
+
+Content to render when image is loading.
+
+|   Type    | Default |
+| :-------: | :-----: |
+| component |  none   |
+
+---
+
+### `placeholderStyle`
+
+Additional styling for the placeholder container (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| View style (object) |  none   |
+
+---
+
+### `transition`
+
+Perform fade transition on image load
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  true   |
+
+---
+
+### `transitionDuration`
+
+Perform fade transition on image load
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |   360   |

--- a/src/content/Image/index.jsx
+++ b/src/content/Image/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./input.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./image.mdx"));
 
 export default function ImagePlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/Input/index.jsx
+++ b/src/content/Input/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./input.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./input.mdx"));
 
 export default function InputPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/Input/input.mdx
+++ b/src/content/Input/input.mdx
@@ -1,0 +1,218 @@
+# Props
+
+> This component inherits
+> [all native TextInput props that come with a standard React Native TextInput element](https://reactnative.dev/docs/textinput.html),
+> along with the following:
+
+- [`containerStyle`](#containerstyle)
+- [`disabled`](#disabled)
+- [`disabledInputStyle`](#disabledinputstyle)
+- [`errorMessage`](#errormessage)
+- [`errorProps`](#errorprops)
+- [`errorStyle`](#errorstyle)
+- [`InputComponent`](#inputcomponent)
+- [`inputContainerStyle`](#inputcontainerstyle)
+- [`inputStyle`](#inputstyle)
+- [`label`](#label)
+- [`labelProps`](#labelprops)
+- [`labelStyle`](#labelstyle)
+- [`leftIcon`](#lefticon)
+- [`leftIconContainerStyle`](#lefticoncontainerstyle)
+- [`renderErrorMessage`](#rendererrormessage)
+- [`rightIcon`](#righticon)
+- [`rightIconContainerStyle`](#righticoncontainerstyle)
+
+---
+
+# Reference
+
+### `containerStyle`
+
+styling for view containing the label, the input and the error message
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| View style (object) |  none   |
+
+---
+
+### `disabled`
+
+disables the input component
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `disabledInputStyle`
+
+disabled styles that will be passed to the `style` props of the React Native `TextInput` (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| Text style (object) |  none   |
+
+---
+
+### `errorMessage`
+
+adds error message (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |
+
+---
+
+### `errorProps`
+
+props to be passed to the React Native `Text` component used to display the
+error message (optional)
+
+|                            Type                            | Default |
+| :--------------------------------------------------------: | :-----: |
+| {[...Text props](https://reactnative.dev/docs/text#props)} |  none   |
+
+---
+
+### `errorStyle`
+
+add styling to error message (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| object |  none   |
+
+---
+
+### `InputComponent`
+
+component that will be rendered in place of the React Native `TextInput`
+(optional)
+
+|          Type          |  Default  |
+| :--------------------: | :-------: |
+| React Native Component | TextInput |
+
+---
+
+### `inputContainerStyle`
+
+styling for Input Component Container (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| View style (object) |  none   |
+
+---
+
+### `inputStyle`
+
+style that will be passed to the `style` props of the React Native `TextInput`
+(optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| object |  none   |
+
+---
+
+### `label`
+
+add a label on top of the input (optional)
+
+|                   Type                   | Default |
+| :--------------------------------------: | :-----: |
+| string **OR** React element or component |  none   |
+
+---
+
+### `labelProps`
+
+props to be passed to the React Native `Text` component used to display the
+label or React Component used instead of simple string in `label` prop
+(optional)
+
+|                                             Type                                              | Default |
+| :-------------------------------------------------------------------------------------------: | :-----: |
+| {[...Text props](https://reactnative.dev/docs/text.html#props)} **OR** passed component props |  none   |
+
+---
+
+### `labelStyle`
+
+styling for the label (optional); You can only use this if `label` is a string
+
+|  Type  | Default |
+| :----: | :-----: |
+| object |  none   |
+
+---
+
+### `leftIcon`
+
+displays an icon on the left (optional)
+
+|                            Type                            | Default |
+| :--------------------------------------------------------: | :-----: |
+| {[...Icon props](icon.md#props)}<br/>**OR**<br/> component |  none   |
+
+---
+
+### `leftIconContainerStyle`
+
+styling for left Icon Component container
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| View style (object) |  none   |
+
+---
+
+### `placeholder`
+
+Placeholder text for the input
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |
+
+---
+
+### `renderErrorMessage`
+
+If the error message container should be rendered (take up vertical space). If `false`, when showing errorMessage, the layout will shift to add it at that time.
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  true   |
+
+---
+
+### `rightIcon`
+
+displays an icon on the right (optional)
+
+|                            Type                            | Default |
+| :--------------------------------------------------------: | :-----: |
+| {[...Icon props](icon.md#props)}<br/>**OR**<br/> component |  none   |
+
+---
+
+### `rightIconContainerStyle`
+
+styling for right Icon Component container
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| View style (object) |  none   |
+
+---
+
+#### Styles explanation
+
+| Input with a label and an error message          | Styles explanation                            |
+| ------------------------------------------------ | --------------------------------------------- |
+| <img src="/img/input_without_explanation.png" /> | <img src="/img/input_with_explanation.png" /> |

--- a/src/content/ListItem/index.jsx
+++ b/src/content/ListItem/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./listitem.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./listitem.mdx"));
 
 export default function ListItemPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/ListItem/listitem.mdx
+++ b/src/content/ListItem/listitem.mdx
@@ -1,0 +1,152 @@
+# Props
+
+> Also receives all
+> [TouchableHighlight](https://reactnative.dev/docs/touchablehighlight#props)
+> props
+
+- [`bottomDivider`](#bottomdivider)
+- [`Component`](#Component)
+- [`containerStyle`](#containerstyle)
+- [`disabled`](#disabled)
+- [`disabledStyle`](#disabledstyle)
+- [`onLongPress`](#onlongpress)
+- [`onPress`](#onpress)
+- [`pad`](#pad)
+- [`topDivider`](#topdivider)
+- [`ViewComponent`](#viewcomponent)
+
+---
+
+# Child Components
+
+### ListItem.ButtonGroup
+
+> Receives all [ButtonGroup](button_group.md#props) props.
+
+### ListItem.CheckBox
+
+> Receives all [CheckBox](checkbox.md#props) props.
+
+### ListItem.Chevron
+
+> Receives all [Icon](icon.md#props) props.
+
+### ListItem.Content
+
+> Receives all [View](https://reactnative.dev/docs/view#props) props.
+
+### ListItem.Input
+
+> Receives all [Input](input.md#props) props.
+
+### ListItem.Subtitle
+
+> Receives all [Text](text.md#props) props.
+
+### ListItem.Title
+
+> Receives all [Text](text.md#props) props.
+
+---
+
+# Reference
+
+### `bottomDivider`
+
+Add divider at the bottom of the list item
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `Component`
+
+replace element with custom element (optional)
+
+|                                  Type                                   |  Default  |
+| :---------------------------------------------------------------------: | :-------: |
+| View or TouchableHighlight (default) if onPress method is added as prop | component |
+
+---
+
+### `containerStyle`
+
+additional main container styling (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `disabled`
+
+If true the user won't be able to perform any action on the list item.
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  none   |
+
+---
+
+### `disabledStyle`
+
+Specific styling to be used when list item is disabled.
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `onLongPress`
+
+onLongPress method for link (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `onPress`
+
+onPress method for link (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `pad`
+
+adds spacing between the leftComponent, the title component & right component
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |  `16`   |
+
+---
+
+### `topDivider`
+
+Add divider at the top of the list item
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `ViewComponent`
+
+Container for linear gradient (for non-expo user)
+
+|   Type    | Default |
+| :-------: | :-----: |
+| component |  View   |
+
+---

--- a/src/content/Overlay/index.jsx
+++ b/src/content/Overlay/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./overlay.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./overlay.mdx"));
 
 export default function OverlayPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/Overlay/overlay.mdx
+++ b/src/content/Overlay/overlay.mdx
@@ -1,0 +1,152 @@
+# Props
+
+> Also receives all
+> [TouchableHighlight](https://reactnative.dev/docs/touchablehighlight#props)
+> props
+
+- [`bottomDivider`](#bottomdivider)
+- [`Component`](#Component)
+- [`containerStyle`](#containerstyle)
+- [`disabled`](#disabled)
+- [`disabledStyle`](#disabledstyle)
+- [`onLongPress`](#onlongpress)
+- [`onPress`](#onpress)
+- [`pad`](#pad)
+- [`topDivider`](#topdivider)
+- [`ViewComponent`](#viewcomponent)
+
+---
+
+# Child Components
+
+### ListItem.ButtonGroup
+
+> Receives all [ButtonGroup](button_group.md#props) props.
+
+### ListItem.CheckBox
+
+> Receives all [CheckBox](checkbox.md#props) props.
+
+### ListItem.Chevron
+
+> Receives all [Icon](icon.md#props) props.
+
+### ListItem.Content
+
+> Receives all [View](https://reactnative.dev/docs/view#props) props.
+
+### ListItem.Input
+
+> Receives all [Input](input.md#props) props.
+
+### ListItem.Subtitle
+
+> Receives all [Text](text.md#props) props.
+
+### ListItem.Title
+
+> Receives all [Text](text.md#props) props.
+
+---
+
+# Reference
+
+### `bottomDivider`
+
+Add divider at the bottom of the list item
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `Component`
+
+replace element with custom element (optional)
+
+|                                  Type                                   |  Default  |
+| :---------------------------------------------------------------------: | :-------: |
+| View or TouchableHighlight (default) if onPress method is added as prop | component |
+
+---
+
+### `containerStyle`
+
+additional main container styling (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `disabled`
+
+If true the user won't be able to perform any action on the list item.
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  none   |
+
+---
+
+### `disabledStyle`
+
+Specific styling to be used when list item is disabled.
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `onLongPress`
+
+onLongPress method for link (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `onPress`
+
+onPress method for link (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `pad`
+
+adds spacing between the leftComponent, the title component & right component
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |  `16`   |
+
+---
+
+### `topDivider`
+
+Add divider at the top of the list item
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `ViewComponent`
+
+Container for linear gradient (for non-expo user)
+
+|   Type    | Default |
+| :-------: | :-----: |
+| component |  View   |
+
+---

--- a/src/content/Pricing/index.jsx
+++ b/src/content/Pricing/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./pricing.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./pricing.mdx"));
 
 export default function PricingPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/Pricing/pricing.mdx
+++ b/src/content/Pricing/pricing.mdx
@@ -1,0 +1,126 @@
+# Props
+
+- [`button`](#button)
+- [`buttonFont`](#buttonfont)
+- [`color`](#color)
+- [`containerStyle`](#containerstyle)
+- [`info`](#info)
+- [`infoFont`](#infofont)
+- [`onButtonPress`](#onbuttonpress)
+- [`price`](#price)
+- [`pricingFont`](#pricingfont)
+- [`title`](#title)
+- [`titleFont`](#titlefont)
+- [`wrapperStyle`](#wrapperstyle)
+
+---
+
+# Reference
+
+### `button`
+
+button information (required)
+
+|                              Type                              | Default |
+| :------------------------------------------------------------: | :-----: |
+| {[...Button props](button.md#props)}<br/>**OR**<br/> component |  none   |
+
+---
+
+### `color`
+
+color scheme for button & title
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |
+
+---
+
+### `containerStyle`
+
+outer component styling (optional)
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `info`
+
+pricing information (optional)
+
+|       Type       | Default |
+| :--------------: | :-----: |
+| array of strings |  none   |
+
+---
+
+### `infoStyle`
+
+specify pricing information style
+
+|      Type      | Default |
+| :------------: | :-----: |
+| style (object) |  none   |
+
+---
+
+### `onButtonPress`
+
+function to be run when button is pressed
+
+| Type | Default |
+| :--: | :-----: |
+| any  |  none   |
+
+---
+
+### `price`
+
+price (required)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |
+
+---
+
+### `pricingStyle`
+
+specify pricing text style
+
+|      Type      | Default |
+| :------------: | :-----: |
+| style (object) |  none   |
+
+---
+
+### `title`
+
+title (required)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |
+
+---
+
+### `titleStyle`
+
+specify title text style
+
+|      Type      | Default |
+| :------------: | :-----: |
+| style (object) |  none   |
+
+---
+
+### `wrapperStyle`
+
+inner wrapper component styling (optional)
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |

--- a/src/content/Rating/index.jsx
+++ b/src/content/Rating/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./searchbar.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./rating.mdx"));
 
 export default function RatingPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/Rating/rating.mdx
+++ b/src/content/Rating/rating.mdx
@@ -1,0 +1,237 @@
+# Props
+
+### AirbnbRating
+
+- [`count`](#count)
+- [`defaultRating`](#defaultrating)
+- [`onFinishRating`](#onfinishrating)
+- [`reviews`](#reviews)
+- [`showRating`](#showrating)
+
+# Rating
+
+- [`fractions`](#fractions)
+- [`imageSize`](#imagesize)
+- [`minValue`](#minValue)
+- [`onFinishRating`](#onfinishrating)
+- [`onStartRating`](#onstartrating)
+- [`ratingBackgroundColor`](#ratingbackgroundcolor)
+- [`tintColor`](#tintColor)
+- [`ratingColor`](#ratingcolor)
+- [`ratingCount`](#ratingcount)
+- [`ratingImage`](#ratingimage)
+- [`ratingTextColor`](#ratingtextcolor)
+- [`readonly`](#readonly)
+- [`showRating`](#showrating)
+- [`startingValue`](#startingvalue)
+- [`style`](#style)
+- [`type`](#type)
+
+---
+
+# Reference
+
+### `count`
+
+Total number of ratings to display
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |    5    |
+
+---
+
+### `defaultRating`
+
+Initial value for the rating
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |    3    |
+
+---
+
+### `fractions`
+
+The number of decimal places for the rating value; must be between 0 and 20
+(optional)
+
+|  Type  |  Default  |
+| :----: | :-------: |
+| number | undefined |
+
+---
+
+### `imageSize`
+
+The size of each rating image (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |   50    |
+
+---
+
+### `minValue`
+
+The minimum value the user can select
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |    0    |
+
+---
+
+### `onFinishRating`
+
+Callback method when the user finishes rating. Gives you the final rating value
+as a whole number **(required)**
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `onStartRating`
+
+Callback method when the user starts the rating. (optional)
+
+|   Type   |  Default  |
+| :------: | :-------: |
+| function | undefined |
+
+---
+
+### `ratingBackgroundColor`
+
+Pass in a custom background-fill-color for the rating icon; use this along with
+`type='custom'` prop above (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| string (color) |  white  |
+
+---
+
+### `tintColor`
+
+Pass in a custom background-color for the rating container; (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| string (color) |  white  |
+
+---
+
+### `ratingColor`
+
+Pass in a custom fill-color for the rating icon; use this along with
+`type='custom'` prop above (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| string (color) | #f1c40f |
+
+---
+
+### `ratingCount`
+
+The number of rating images to display (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |    5    |
+
+---
+
+### `ratingImage`
+
+Pass in a custom image source; use this along with `type='custom'` prop above
+(optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  star   |
+
+---
+
+### `ratingTextColor`
+
+Pass in a custom text color for the rating text (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| string (color) | #f1c40f |
+
+---
+
+### `readonly`
+
+Whether the rating can be modified by the user (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `reviews`
+
+Labels to show when each value is tapped
+e.g. If the first star is tapped, then value in index 0 will be used as the label
+
+|   Type   |                   Default                    |
+| :------: | :------------------------------------------: |
+| string[] | ['Terrible', 'Bad', 'Okay', 'Good', 'Great'] |
+
+---
+
+### `showRating`
+
+Determines if to show the reviews above the rating
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  true   |
+
+---
+
+### `showRating`
+
+Displays the Built-in Rating UI to show the rating value in real-time (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  none   |
+
+---
+
+### `startingValue`
+
+The initial rating to render (optional)
+
+|  Type  |     Default     |
+| :----: | :-------------: |
+| number | ratingCount / 2 |
+
+---
+
+### `style`
+
+Exposes style prop to add additional styling to the container view (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `type`
+
+Choose one of the built-in types: `star`, `rocket`, `bell`, `heart` or use type
+`custom` to render a custom image (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  star   |

--- a/src/content/SearchBar/index.jsx
+++ b/src/content/SearchBar/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./searchbar.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./searchbar.mdx"));
 
 export default function SearchBarPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/SearchBar/searchbar.mdx
+++ b/src/content/SearchBar/searchbar.mdx
@@ -1,0 +1,322 @@
+# Props
+
+> This component inherits all
+> [React Native Elements Input props](input.md#props),
+> which means
+> [all native TextInput props that come with a standard React Native TextInput element](https://reactnative.dev/docs/textinput.html),
+> along with the following:
+
+- [`cancelButtonProps`](#cancelbuttonprops)
+- [`cancelButtonTitle`](#cancelbuttontitle)
+- [`cancelIcon`](#cancelicon-platformandroid-only) (**`platform="android"`
+  only**)
+- [`clearIcon`](#clearicon)
+- [`containerStyle`](#containerstyle)
+- [`inputContainerStyle`](#inputcontainerstyle)
+- [`inputStyle`](#inputstyle)
+- [`leftIconContainerStyle`](#lefticoncontainerstyle)
+- [`lightTheme`](#lighttheme-platformdefault-only) (**`platform="default"`
+  only**)
+- [`loadingProps`](#loadingprops)
+- [`onCancel`](#oncancel)
+- [`onChangeText`](#onchangetext)
+- [`onClear`](#onclear)
+- [`placeholder`](#placeholder)
+- [`placeholderTextColor`](#placeholdertextcolor)
+- [`platform`](#platform)
+- [`rightIconContainerStyle`](#righticoncontainerstyle)
+- [`round`](#round-platformdefault-only) (**`platform="default"` only**)
+- [`searchIcon`](#searchicon)
+- [`showCancel`](#showcancel-platformios-only) (**`platform="ios"` only**)
+- [`showLoading`](#showloading)
+- [`underlineColorAndroid`](#underlinecolorandroid)
+
+---
+
+# Reference
+
+### `cancelButtonProps`
+
+**(iOS only)** props passed to cancel Button
+
+> Also receives all
+> [TouchableOpacity](http://reactnative.dev/docs/touchableopacity.html#props)
+> props
+
+- [`buttonStyle`](#buttonstyle)
+- [`buttonTextStyle`](#buttontextstyle)
+- [`color`](#color)
+- [`disabled`](#disabled)
+- [`buttonDisabledStyle`](#buttondisabledstyle)
+- [`buttonDisabledTextStyle`](#buttondisabledtextstyle)
+
+#### `buttonStyle`
+
+cancel Button styling
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+#### `buttonTextStyle`
+
+cancel Button Text styling
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+#### `color`
+
+cancel Button text color
+
+|      Type      | Default |
+| :------------: | :-----: |
+| string (color) | #007aff |
+
+#### `disabled`
+
+Prop to indicate cancel Button is disabled
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+#### `buttonDisabledStyle`
+
+Disabled cancel Button styling
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+#### `buttonDisabledTextStyle`
+
+Styles for the text when cancel Button is disabled
+
+|      Type      |        Default         |
+| :------------: | :--------------------: |
+| object (style) | `{ color: '#cdcdcd' }` |
+
+---
+
+### `cancelButtonTitle`
+
+**(iOS only)** title of the cancel button on the right side
+
+|  Type  | Default  |
+| :----: | :------: |
+| string | "Cancel" |
+
+---
+
+### `cancelIcon` (**`platform="android"` only**)
+
+This props allows to override the `Icon` props or use a custom component. Use
+`null` or `false` to hide the icon.
+
+|                            Type                            | Default |
+| :--------------------------------------------------------: | :-----: |
+| {[...Icon props](icon.md#props)}<br/>**OR**<br/> component |  none   |
+
+---
+
+### `clearIcon`
+
+This props allows to override the `Icon` props or use a custom component. Use
+`null` or `false` to hide the icon.
+
+|                            Type                            | Default |
+| :--------------------------------------------------------: | :-----: |
+| {[...Icon props](icon.md#props)}<br/>**OR**<br/> component |  none   |
+
+---
+
+### `containerStyle`
+
+style the container of the SearchBar
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `inputContainerStyle`
+
+style the container of the TextInput
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `inputStyle`
+
+style the TextInput
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `leftIconContainerStyle`
+
+style the icon container on the left side
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `lightTheme` (**`platform="default"` only**)
+
+change theme to light theme
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `loadingProps`
+
+props passed to ActivityIndicator
+
+|  Type  | Default |
+| :----: | :-----: |
+| object |   { }   |
+
+---
+
+### `onCancel`
+
+callback fired when pressing the cancel button (iOS) or the back icon (Android)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  null   |
+
+---
+
+### `onChangeText`
+
+method to fire when text is changed
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `onClear`
+
+method to fire when input is cleared
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `placeholder`
+
+set the placeholder text
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |   ''    |
+
+---
+
+### `placeholderTextColor`
+
+set the color of the placeholder text
+
+|  Type  |  Default  |
+| :----: | :-------: |
+| string | '#86939e' |
+
+---
+
+### `platform`
+
+choose the look and feel of the search bar. One of "default", "ios", "android"
+
+|  Type  |  Default  |
+| :----: | :-------: |
+| string | "default" |
+
+---
+
+### `rightIconContainerStyle`
+
+style the icon container on the right side
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `round` (**`platform="default"` only**)
+
+change TextInput styling to rounded corners
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `searchIcon`
+
+This props allows to override the `Icon` props or use a custom component. Use
+`null` or `false` to hide the icon.
+
+|                            Type                            | Default |
+| :--------------------------------------------------------: | :-----: |
+| {[...Icon props](icon.md#props)}<br/>**OR**<br/> component |  none   |
+
+---
+
+### `showCancel` (**`platform="ios"` only**)
+
+When `true` the cancel button will stay visible after blur events.
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `showLoading`
+
+show the loading ActivityIndicator effect
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `underlineColorAndroid`
+
+specify other than the default transparent underline color
+
+|      Type      |   Default   |
+| :------------: | :---------: |
+| string (color) | transparent |
+
+---
+
+### `value`
+
+The value of the search field
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |

--- a/src/content/Slider/index.jsx
+++ b/src/content/Slider/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./slider.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./slider.mdx"));
 
 export default function SliderPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/Slider/slider.mdx
+++ b/src/content/Slider/slider.mdx
@@ -1,0 +1,254 @@
+# Props
+
+- [`allowTouchTrack`](#allowtouchtrack)
+- [`animateTransitions`](#animatetransitions)
+- [`animationConfig`](#animationconfig)
+- [`animationType`](#animationtype)
+- [`debugTouchArea`](#debugtoucharea)
+- [`disabled`](#disabled)
+- [`maximumTrackTintColor`](#maximumtracktintcolor)
+- [`maximumValue`](#maximumvalue)
+- [`minimumTrackTintColor`](#minimumtracktintcolor)
+- [`minimumValue`](#minimumvalue)
+- [`onSlidingComplete`](#onslidingcomplete)
+- [`onSlidingStart`](#onslidingstart)
+- [`onValueChange`](#onvaluechange)
+- [`orientation`](#orientation)
+- [`step`](#step)
+- [`style`](#style)
+- [`thumbProps`](#thumbprops)
+- [`thumbStyle`](#thumbstyle)
+- [`thumbTintColor`](#thumbtintcolor)
+- [`thumbTouchSize`](#thumbtouchsize)
+- [`trackStyle`](#trackstyle)
+- [`value`](#value)
+
+---
+
+# Reference
+
+### `allowTouchTrack`
+
+If true, thumb will respond and jump to any touch along the track.
+
+|  Type   | Default | Optional |
+| :-----: | :-----: | :------: |
+| boolean |  false  |   Yes    |
+
+---
+
+### `animateTransitions`
+
+Set to true if you want to use the default 'spring' animation
+
+| Type | Default | Optional |
+| :--: | :-----: | :------: |
+| bool |  false  |   Yes    |
+
+---
+
+### `animationConfig`
+
+Used to configure the animation parameters. These are the same parameters in the
+[Animated library](https://reactnative.dev/docs/animations.html).
+
+|  Type  |  Default  | Optional |
+| :----: | :-------: | :------: |
+| object | undefined |   Yes    |
+
+---
+
+### `animationType`
+
+Set to 'spring' or 'timing' to use one of those two types of animations with the
+default
+[animation properties](https://reactnative.dev/docs/animations.html).
+
+|  Type  | Default  | Optional |
+| :----: | :------: | :------: |
+| string | 'timing' |   Yes    |
+
+---
+
+### `debugTouchArea`
+
+Set this to true to visually see the thumb touch rect in green.
+
+| Type | Default | Optional |
+| :--: | :-----: | :------: |
+| bool |  false  |   Yes    |
+
+---
+
+### `disabled`
+
+If true the user won't be able to move the slider
+
+| Type | Default | Optional |
+| :--: | :-----: | :------: |
+| bool |  false  |   Yes    |
+
+---
+
+### `maximumTrackTintColor`
+
+The color used for the track to the right of the button
+
+|  Type  |  Default  | Optional |
+| :----: | :-------: | :------: |
+| string | '#b3b3b3' |   Yes    |
+
+---
+
+### `maximumValue`
+
+Initial maximum value of the slider
+
+|  Type  | Default | Optional |
+| :----: | :-----: | :------: |
+| number |    1    |   Yes    |
+
+---
+
+### `minimumTrackTintColor`
+
+The color used for the track to the left of the button
+
+|  Type  |  Default  | Optional |
+| :----: | :-------: | :------: |
+| string | '#3f3f3f' |   Yes    |
+
+---
+
+### `minimumValue`
+
+Initial minimum value of the slider
+
+|  Type  | Default | Optional |
+| :----: | :-----: | :------: |
+| number |    0    |   Yes    |
+
+---
+
+### `onSlidingComplete`
+
+Callback called when the user finishes changing the value (e.g. when the slider
+is released)
+
+|   Type   | Default | Optional |
+| :------: | :-----: | :------: |
+| function |         |   Yes    |
+
+---
+
+### `onSlidingStart`
+
+Callback called when the user starts changing the value (e.g. when the slider is
+pressed)
+
+|   Type   | Default | Optional |
+| :------: | :-----: | :------: |
+| function |         |   Yes    |
+
+---
+
+### `onValueChange`
+
+Callback continuously called while the user is dragging the slider
+
+|   Type   | Default | Optional |
+| :------: | :-----: | :------: |
+| function |         |   Yes    |
+
+---
+
+### `orientation`
+
+Set the orientation of the slider.
+
+|  Type  |   Default    | Optional |
+| :----: | :----------: | :------: |
+| string | 'horizontal' |   Yes    |
+
+---
+
+### `step`
+
+Step value of the slider. The value should be between 0 and maximumValue -
+minimumValue)
+
+|  Type  | Default | Optional |
+| :----: | :-----: | :------: |
+| number |    0    |   Yes    |
+
+---
+
+### `style`
+
+The style applied to the slider container
+
+|                         Type                         | Default | Optional |
+| :--------------------------------------------------: | :-----: | :------: |
+| [style](http://reactnative.dev/docs/view.html#style) |         |   Yes    |
+
+---
+
+### `thumbProps`
+
+The props applied to the thumb. Uses `Component` prop which can accept `Animated` components.
+
+|  Type  | Default | Optional |
+| :----: | :-----: | :------: |
+| object |         |   Yes    |
+
+---
+
+### `thumbStyle`
+
+The style applied to the thumb
+
+|                         Type                         | Default | Optional |
+| :--------------------------------------------------: | :-----: | :------: |
+| [style](http://reactnative.dev/docs/view.html#style) |         |   Yes    |
+
+---
+
+### `thumbTintColor`
+
+The color used for the thumb
+
+|  Type  |  Default  | Optional |
+| :----: | :-------: | :------: |
+| string | '#343434' |   Yes    |
+
+---
+
+### `thumbTouchSize`
+
+The size of the touch area that allows moving the thumb. The touch area has the
+same center as the visible thumb. This allows to have a visually small thumb
+while still allowing the user to move it easily.
+
+|  Type  |          Default          | Optional |
+| :----: | :-----------------------: | :------: |
+| object | `{width: 40, height: 40}` |   Yes    |
+
+---
+
+### `trackStyle`
+
+The style applied to the track
+
+|                         Type                         | Default | Optional |
+| :--------------------------------------------------: | :-----: | :------: |
+| [style](http://reactnative.dev/docs/view.html#style) |         |   Yes    |
+
+---
+
+### `value`
+
+Initial value of the slider
+
+|  Type  | Default | Optional |
+| :----: | :-----: | :------: |
+| number |    0    |   Yes    |

--- a/src/content/SocialIcon/index.jsx
+++ b/src/content/SocialIcon/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./socialicon.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./socialicon.mdx"));
 
 export default function SocialIconPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/SocialIcon/socialicon.mdx
+++ b/src/content/SocialIcon/socialicon.mdx
@@ -1,0 +1,214 @@
+# Props
+
+- [`button`](#button)
+- [`Component`](#Component)
+- [`disabled`](#disabled)
+- [`fontFamily`](#fontfamily)
+- [`fontStyle`](#fontstyle)
+- [`fontWeight`](#fontweight)
+- [`iconColor`](#iconcolor)
+- [`iconSize`](#iconsize)
+- [`iconStyle`](#iconstyle)
+- [`iconType`](#icontype)
+- [`light`](#light)
+- [`loading`](#loading)
+- [`onLongPress`](#onlongpress)
+- [`onPress`](#onpress)
+- [`raised`](#raised)
+- [`style`](#style)
+- [`title`](#title)
+- [`type`](#type)
+- [`underlayColor`](#underlaycolor)
+
+---
+
+# Reference
+
+### `button`
+
+creates button (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `Component`
+
+type of button (optional)
+
+|          Type          |      Default       |
+| :--------------------: | :----------------: |
+| React Native Component | TouchableHighlight |
+
+---
+
+### `disabled`
+
+disable button (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `fontFamily`
+
+specify different font family (optional)
+
+|  Type  |                      Default                       |
+| :----: | :------------------------------------------------: |
+| string | System font bold (iOS), Sans Serif Black (android) |
+
+---
+
+### `fontStyle`
+
+specify text styling (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `fontWeight`
+
+specify font weight of title if set as a button with a title
+
+|  Type  |          Default           |
+| :----: | :------------------------: |
+| string | bold (ios), black(android) |
+
+---
+
+### `iconColor`
+
+icon color (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  white  |
+
+---
+
+### `iconSize`
+
+icon size (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |   24    |
+
+---
+
+### `iconStyle`
+
+extra styling for icon component (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `iconType`
+
+type of icon set. [Supported sets here](./icon.md#available-icon-sets).
+
+|  Type  |   Default    |
+| :----: | :----------: |
+| string | font-awesome |
+
+---
+
+### `light`
+
+reverses icon color scheme, setting background to white and icon to primary
+color
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `loading`
+
+shows loading indicator (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `onLongPress`
+
+onLongPress method (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `onPress`
+
+onPress method (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  none   |
+
+---
+
+### `raised`
+
+raised adds a drop shadow, set to false to remove
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  true   |
+
+---
+
+### `style`
+
+button styling (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `title`
+
+title if made into a button (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |
+
+---
+
+### `type`
+
+social media type (required)
+
+|                                                                                                                                                            Type                                                                                                                                                            | Default |
+| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
+| social media type (angellist, codepen, envelope, etsy, facebook, flickr, foursquare, github-alt, github, gitlab, instagram, linkedin, medium, pinterest, quora, reddit-alien, soundcloud, stack-overflow, steam, stumbleupon, tumblr, twitch, twitter, google, google-plus-official, vimeo, vk, weibo, wordpress, youtube) |  none   |
+
+---
+
+### `underlayColor`
+
+underlay color (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |

--- a/src/content/Text/index.jsx
+++ b/src/content/Text/index.jsx
@@ -1,10 +1,20 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./tooltip.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./text.mdx"));
+
 
 export default function TextPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/Text/text.mdx
+++ b/src/content/Text/text.mdx
@@ -1,0 +1,103 @@
+# Props
+
+- [`h1`](#h1)
+- [`h1Style`](#h1style)
+- [`h2`](#h2)
+- [`h2Style`](#h2style)
+- [`h3`](#h3)
+- [`h3Style`](#h3style)
+- [`h4`](#h4)
+- [`h4Style`](#h4style)
+- [`style`](#style)
+
+---
+
+# Reference
+
+### `h1`
+
+font size 40 (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  none   |
+
+---
+
+### `h1Style`
+
+Styling for when `h1` is set (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| Text style (object) |  none   |
+
+---
+
+### `h2`
+
+font size 34 (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  none   |
+
+---
+
+### `h2Style`
+
+Styling for when `h2` is set (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| Text style (object) |  none   |
+
+---
+
+### `h3`
+
+font size 28 (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  none   |
+
+---
+
+### `h3Style`
+
+Styling for when `h3` is set (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| Text style (object) |  none   |
+
+---
+
+### `h4`
+
+font size 22 (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  none   |
+
+---
+
+### `h4Style`
+
+Styling for when `h4` is set (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| Text style (object) |  none   |
+
+---
+
+### `style`
+
+add additional styling for Text (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| Text style (object) |  none   |

--- a/src/content/Tile/index.jsx
+++ b/src/content/Tile/index.jsx
@@ -3,7 +3,7 @@ import Playground from "./tile.playground.jsx";
 import { importMDX } from "mdx.macro";
 import PropDrawer from "../../components/PropDrawer";
 
-const Content = lazy(() => importMDX("./text.mdx"));
+const Content = lazy(() => importMDX("./tile.mdx"));
 
 export default function TilePlayground() {
   return (

--- a/src/content/Tile/index.jsx
+++ b/src/content/Tile/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./tile.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./text.mdx"));
 
 export default function TilePlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 };

--- a/src/content/Tile/tile.mdx
+++ b/src/content/Tile/tile.mdx
@@ -1,0 +1,219 @@
+# Props
+
+> Also receives all
+> [TouchableNativeFeedback](http://reactnative.dev/docs/touchablenativefeedback.html#props)
+> (Android) or
+> [TouchableOpacity](http://reactnative.dev/docs/touchableopacity.html#props)
+> (iOS) props
+
+- [`activeOpacity`](#activeopacity)
+- [`caption`](#caption)
+- [`captionStyle`](#captionstyle)
+- [`containerStyle`](#containerstyle)
+- [`contentContainerStyle`](#contentcontainerstyle)
+- [`featured`](#featured)
+- [`height`](#height)
+- [`icon`](#icon)
+- [`iconContainerStyle`](#iconcontainerstyle)
+- [`ImageComponent`](#imagecomponent)
+- [`imageContainerStyle`](#imagecontainerstyle)
+- [`imageProps`](#imageprops)
+- [`imageSrc`](#imagesrc)
+- [`onPress`](#onpress)
+- [`overlayContainerStyle`](#overlaycontainerstyle)
+- [`title`](#title)
+- [`titleNumberOfLines`](#titlenumberoflines)
+- [`titleStyle`](#titlestyle)
+- [`width`](#width)
+
+---
+
+# Reference
+
+### `activeOpacity`
+
+Number passed to control opacity on press (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |   0.2   |
+
+---
+
+### `caption`
+
+Text inside the tilt when tile is featured
+
+|                   Type                   | Default |
+| :--------------------------------------: | :-----: |
+| string **OR** React element or component |  none   |
+
+---
+
+### `captionStyle`
+
+Styling for the caption (optional); You only use this if `caption` is a string
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `containerStyle`
+
+Styling for the outer tile container (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `contentContainerStyle`
+
+Styling for bottom container when not featured tile (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `featured`
+
+Changes the look of the tile (optional)
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `height`
+
+Height for the tile
+
+|  Type  |       Default       |
+| :----: | :-----------------: |
+| number | Device Width \* 0.8 |
+
+---
+
+### `icon`
+
+Icon Component Props (optional)
+
+|                                                                                        Type                                                                                         | Default |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
+| object {name: string, color: string, size: number, type: string (default is material, or choose from [supported icon sets](icon.md#available-icon-sets)), iconStyle: object(style)} |  none   |
+
+---
+
+### `iconContainerStyle`
+
+Styling for the outer icon container (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `ImageComponent`
+
+Custom ImageComponent for Tile
+
+|            Type            |     Default     |
+| :------------------------: | :-------------: |
+| React component or element | BackgroundImage |
+
+---
+
+### `imageContainerStyle`
+
+Styling for the image (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `imageProps`
+
+Optional properties to pass to the image if provided e.g "resizeMode" (options)
+
+|                Type                | Default |
+| :--------------------------------: | :-----: |
+| {[...Image props](image.md#props)} |  none   |
+
+---
+
+### `imageSrc`
+
+Source for the image (required)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (image) |  none   |
+
+---
+
+### `onPress`
+
+Function to call when tile is pressed (optional)
+
+|       Type       | Default |
+| :--------------: | :-----: |
+| function (event) |  none   |
+
+---
+
+### `overlayContainerStyle`
+
+Styling for the overlay container when using featured tile (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| View style (object) |  none   |
+
+---
+
+### `title`
+
+Text inside the tile (optional)
+
+|  Type  | Default |
+| :----: | :-----: |
+| string |  none   |
+
+---
+
+### `titleNumberOfLines`
+
+Number of lines for Title
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |  none   |
+
+---
+
+### `titleStyle`
+
+Styling for the title (optional)
+
+|      Type      | Default |
+| :------------: | :-----: |
+| object (style) |  none   |
+
+---
+
+### `width`
+
+Width for the tile (optional)
+
+|  Type  |   Default    |
+| :----: | :----------: |
+| number | Device Width |

--- a/src/content/ToolTip/index.jsx
+++ b/src/content/ToolTip/index.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import Playground from "./tooltip.playground.jsx";
+import { importMDX } from "mdx.macro";
+import PropDrawer from "../../components/PropDrawer";
+
+const Content = lazy(() => importMDX("./tooltip.mdx"));
 
 export default function ToolTipPlayground() {
   return (
     <div>
       <Playground />
+      <Suspense fallback={<div>Loading...</div>}>
+        <PropDrawer>
+          <Content />
+        </PropDrawer>
+      </Suspense>
     </div>
   );
 }

--- a/src/content/ToolTip/tooltip.mdx
+++ b/src/content/ToolTip/tooltip.mdx
@@ -1,0 +1,231 @@
+# Props
+
+- [`backgroundColor`](#backgroundcolor)
+- [`closeOnlyOnBackdropPress`](#closeonlyonbackdroppress)
+- [`containerStyle`](#containerstyle)
+- [`height`](#height)
+- [`highlightColor`](#highlightcolor)
+- [`ModalComponent`](#modalcomponent)
+- [`onClose`](#onclose)
+- [`onOpen`](#onopen)
+- [`overlayColor`](#overlaycolor)
+- [`pointerColor`](#pointercolor)
+- [`popover`](#popover)
+- [`skipAndroidStatusBar`](#skipandroidstatusbar)
+- [`toggleAction`](#toggleaction)
+- [`toggleOnPress`](#toggleonpress)
+- [`width`](#width)
+- [`withOverlay`](#withoverlay)
+- [`withPointer`](#withpointer)
+
+---
+
+# Reference
+
+### `backgroundColor`
+
+sets backgroundColor of the tooltip and pointer.
+
+|  Type  | Default |
+| :----: | :-----: |
+| string | #617080 |
+
+---
+
+### `closeOnlyOnBackdropPress`
+
+Flag to determine whether to disable auto hiding of tooltip when touching/scrolling anywhere inside the active tooltip popover container.
+
+- When `true`, Tooltip closes only when overlay backdrop is pressed (or) highlighted tooltip button is pressed.
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `containerStyle`
+
+Passes style object to tooltip container
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `height`
+
+Tooltip container height. Necessary in order to render the container in the
+correct place. Pass height according to the size of the content rendered inside
+the container.
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |   40    |
+
+---
+
+### `highlightColor`
+
+Color to highlight the item the tooltip is surrounding.
+
+|  Type  |   Default   |
+| :----: | :---------: |
+| string | transparent |
+
+---
+
+### `ModalComponent`
+
+override React Native `Modal` component (usable for web-platform)
+
+|          Type          | Default |
+| :--------------------: | :-----: |
+| React Native Component |  Modal  |
+
+## Interaction methods
+
+| method        | description                                                    |
+| ------------- | -------------------------------------------------------------- |
+| toggleTooltip | Toggles tooltip manually. ([example](#toggle-tooltip-example)) |
+
+#### `toggleTooltip` example
+
+Store a reference to the Tooltip in your component by using the ref prop
+provided by React ([see docs](https://reactjs.org/docs/refs-and-the-dom.html)):
+
+```js
+const tooltipRef = useRef(null);
+
+...
+
+<Tooltip
+  ref={tooltipRef}
+  ...
+/>
+```
+
+Then you can manually trigger tooltip from anywhere for example when screen loads:
+
+```js
+useEffect(() => {
+  tooltipRef.current.toggleTooltip();
+}, []);
+```
+
+---
+
+### `onClose`
+
+function which gets called on closing the tooltip.
+
+|   Type   | Default  |
+| :------: | :------: |
+| function | () => {} |
+
+---
+
+### `onOpen`
+
+function which gets called on opening the tooltip.
+
+|   Type   | Default  |
+| :------: | :------: |
+| function | () => {} |
+
+---
+
+### `overlayColor`
+
+Color of overlay shadow when tooltip is open.
+
+|  Type  |           Default           |
+| :----: | :-------------------------: |
+| string | 'rgba(250, 250, 250, 0.70)' |
+
+---
+
+### `pointerColor`
+
+Color of tooltip pointer, it defaults to the
+[`backgroundColor`](#backgroundcolor) if none is passed .
+
+|  Type  |                Default                |
+| :----: | :-----------------------------------: |
+| string | [`backgroundColor`](#backgroundcolor) |
+
+---
+
+### `popover`
+
+Component to be rendered as the display container.
+
+|     Type      | Default |
+| :-----------: | :-----: |
+| React.Element |  null   |
+
+---
+
+### `skipAndroidStatusBar`
+
+Force skip StatusBar height when calculating element position. Pass `true` if Tooltip used inside react-native Modal component.
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `toggleAction`
+
+Define type of action that should trigger tooltip.
+Available options _onPress_, _onLongPress_
+
+|  Type  | Default |
+| :----: | :-----: |
+| string | onPress |
+
+---
+
+### `toggleOnPress`
+
+Flag to determine to toggle or not the tooltip on press.
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  true   |
+
+---
+
+### `width`
+
+Tooltip container width. Necessary in order to render the container in the
+correct place. Pass height according to the size of the content rendered inside
+the container.
+
+|  Type  | Default |
+| :----: | :-----: |
+| number |   150   |
+
+---
+
+### `withOverlay`
+
+Flag to determine whether or not display overlay shadow when tooltip is open.
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  true   |
+
+---
+
+### `withPointer`
+
+Flag to determine whether or not to display the pointer.
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  true   |
+
+---


### PR DESCRIPTION
### **What kind of change does this PR introduce?**

-  Add to 9 prop_explorers with complete prop detailings from RNE CORE .

### **Did you add tests for your changes?**

- Not required (manually tested)

### **If relevant, did you update the documentation?**

- Not required

### **Summary**

Fixes #43 

###    Motivation
  -  Props explorer are only introduced in some of the components.

### **props updated**

![Screenshot from 2021-03-14 12-31-44](https://user-images.githubusercontent.com/50916299/111060228-47050d00-84c1-11eb-9f63-92b00766b2ad.png)
![Screenshot from 2021-03-15 12-34-27](https://user-images.githubusercontent.com/50916299/111115607-de826280-858a-11eb-94e9-2886256f0b71.png)

**Does this PR introduce a breaking change?**

- New files are introduced `mdx`. so chances of conflict or any breaking of the application.

**Other information**

-  Working on improving styling.

@pranshuchittora, I have done with the discussed changes. Kindly review it.