### PR TITLE
Enabled Deselection of item from the side bar on navigating to the home page.

### DIFF
--- a/src/components/playground/index.jsx
+++ b/src/components/playground/index.jsx
@@ -15,7 +15,7 @@ export default ({ params }) => {
       <div
         style={{
           border: "1px dashed #ccc",
-          position:'relative'
+          position: "relative",
         }}
       >
         <Compiler

--- a/src/containers/Drawer/index.jsx
+++ b/src/containers/Drawer/index.jsx
@@ -77,7 +77,7 @@ function ResponsiveDrawer(props) {
   const [selectedIndex, setSelectedIndex] = React.useState(-1);
 
   const handleDrawerToggle = (value) => {
-    if(value === false){
+    if (value === false) {
       setMobileOpen(false);
     } else {
       setMobileOpen(true);
@@ -91,7 +91,7 @@ function ResponsiveDrawer(props) {
   const drawer = (
     <div>
       <div style={{ padding: "0.5rem" }}>
-        <Link to="/">
+        <Link to="/" onClick={(event) => handleListItemClick(event, -1)}>
           <Typography variant="h5">Playground 🚀</Typography>
         </Link>
       </div>
@@ -134,7 +134,7 @@ function ResponsiveDrawer(props) {
           >
             <MenuIcon />
           </IconButton>
-          <Link to="/">
+          <Link to="/" onClick={(event) => handleListItemClick(event, -1)}>
             <Typography variant="h6" noWrap>
               React Native Elements
             </Typography>

--- a/src/content/Input/input.playground.jsx
+++ b/src/content/Input/input.playground.jsx
@@ -7,8 +7,6 @@ import Playground from "../../components/playground";
 import { useView, PropTypes } from "react-view";
 
 const InputPlayground = () => {
-  const [inputField, setInputField] = useState("Hello");
-
   const params = useView({
     componentName: "Input",
     props: {

--- a/src/content/Input/input.playground.jsx
+++ b/src/content/Input/input.playground.jsx
@@ -7,6 +7,8 @@ import Playground from "../../components/playground";
 import { useView, PropTypes } from "react-view";
 
 const InputPlayground = () => {
+  const [inputField, setInputField] = useState("Hello");
+
   const params = useView({
     componentName: "Input",
     props: {


### PR DESCRIPTION
Say, we click on any component on the sideBar, (say, Header), now, we are directed to the header page and header is selected with a grey coloured selection on the side bar.......
<img width="1440" alt="Header_selection" src="https://user-images.githubusercontent.com/63174870/111249583-ef39e380-8631-11eb-8205-8e0f65582f35.png">


Issue:
Now, if I click on the playground title or the react-native-elements i am redirected to the home page, but, the header was still selected....
<img width="1435" alt="Issue" src="https://user-images.githubusercontent.com/63174870/111249818-52c41100-8632-11eb-960f-fb4c77b8d9f1.png">



The above issue is solved with this commit
Now, going to the home page, deselects the item from the sideBar